### PR TITLE
Add 'accept-encoding: gzip' header so http responses are gzipped

### DIFF
--- a/R/XmlstatsCache.R
+++ b/R/XmlstatsCache.R
@@ -16,7 +16,7 @@
   }
   
   ## IF ONE OF THESE PARAMS THEN ADD TO httpheader
-  validHeaders <- c("Authorization", "User-Agent", "Accept")
+  validHeaders <- c("Authorization", "User-Agent", "Accept", "Accept-Encoding")
   if(key %in% validHeaders){
     httpheader <- .getXmlstatsCache("httpheader")
     httpheader[[key]] <- value

--- a/R/getXmlstatsJSON.R
+++ b/R/getXmlstatsJSON.R
@@ -3,7 +3,7 @@
 
 .getXmlstatsJSON <- function(url, .opts, httpheader, ...){
   
-  tryGetURL <- getURL(url, .opts=.opts, .encoding='UTF-8',
+  tryGetURL <- getURL(url, .opts=.opts, .encoding='UTF-8', encoding='gzip',
                       httpheader=httpheader, ...)
   tryGetURL <- fromJSON(tryGetURL)
   

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,6 +10,7 @@ kCertBundle <- "certificateBundle/cacert.pem"
   .setXmlstatsCache("xmlstatsEndpoint", "https://erikberg.com/")
   .setXmlstatsCache("httpheader", character())
   .setXmlstatsCache("User-Agent", .userAgent())
+  .setXmlstatsCache("Accept-Encoding", "gzip")
   .setXmlstatsCache("low.speed.time", 60)
   .setXmlstatsCache("low.speed.limit", 1)
   .setXmlstatsCache("connecttimeout", 300)


### PR DESCRIPTION
First time using R... powerful functions. Takes some getting used to the documentation style, though. Looks circa 1990!
